### PR TITLE
Fix #8

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -111,7 +111,7 @@ permissions:
      essentialstp.command.home:
       description: "Allows player to use the home command"
       default: true
-     essentialstp.command.bedsetshome:
+     essentialstp.command.bedsethome:
       description: "Allows player to set home with there bed"
       default: true
      essentialstp.command.sign.warp:


### PR DESCRIPTION
Fix #8  bedsethome can now work for non-op. Originally thought it was because night couldn't refresh instantly with more than one player, but turned out to be permission typo. 