### PR TITLE
Fix for /wild

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -8,6 +8,7 @@ tp-spawn-cooldown: "5"
 MOTD: Welcome to this awsome plugin showcase was hell for the first day but hey lol
 wild-MaxX: "300"
 wild-MaxY: "300"
+wild-MaxZ: "300"
 bed-sets-home: "true"
 Lang_invalid_usage: 'INVALID USAGE:'
 Lang_command_only_use_ingame: This command can only be used in the game.

--- a/src/essentialsTP/essentialsTP.php
+++ b/src/essentialsTP/essentialsTP.php
@@ -257,15 +257,15 @@ class essentialsTP extends PluginBase  implements CommandExecutor, Listener {
                 {
                     if ($this->world == $curr_world->getName())
                     {
-                        $pos = $player->getLevel()->getSafeSpawn(new Vector3(rand('-'.$this->config->get("wild-MaxX"), $this->config->get("wild-MaxX")),rand(70,100),rand('-'.$this->config->get("wild-MaxY"), $this->config->get("wild-MaxY"))));
+                        $pos = $player->getLevel()->getSafeSpawn(new Vector3(rand('-'.$this->config->get("wild-MaxX"), $this->config->get("wild-MaxX")),rand(75,$this->config->get("wild-MaxY")),rand('-'.$this->config->get("wild-MaxZ"), $this->config->get("wild-MaxZ"))));
                         $pos->getLevel()->loadChunk($pos->getX(),$pos->getZ());
                         $pos->getLevel()->getChunk($pos->getX(),$pos->getZ(),true);
                         $pos->getLevel()->generateChunk($pos->getX(),$pos->getZ());
-                        $pos = $pos->getLevel()->getSafeSpawn(new Vector3($pos->getX(),rand(4,100),$pos->getZ()));
+                        $pos = $pos->getLevel()->getSafeSpawn(new Vector3($pos->getX(),$pos->getY(),$pos->getZ()));
 
                         if($pos->getLevel()->isChunkLoaded($pos->getX(),$pos->getZ()))
                         {
-                            $player->teleport($pos->getLevel()->getSafeSpawn(new Vector3($pos->getX(),rand(4,100),$pos->getZ())));
+                            $player->teleport($pos->getLevel()->getSafeSpawn(new Vector3($pos->getX(),$pos->getY(),$pos->getZ())));
                             $player->sendMessage($this->config->get("Lang_teleport_wild"));
                             return true;
                         }
@@ -1043,11 +1043,11 @@ class essentialsTP extends PluginBase  implements CommandExecutor, Listener {
                     {
                         if ($this->world == $curr_world->getName())
                         {
-                            $pos = $sender->getLevel()->getSafeSpawn(new Vector3(rand('-'.$this->config->get("wild-MaxX"), $this->config->get("wild-MaxX")),rand(70,100),rand('-'.$this->config->get("wild-MaxY"), $this->config->get("wild-MaxY"))));
+                            $pos = $sender->getLevel()->getSafeSpawn(new Vector3(rand('-'.$this->config->get("wild-MaxX"), $this->config->get("wild-MaxX")),rand(75,$this->config->get("wild-MaxY")),rand('-'.$this->config->get("wild-MaxZ"), $this->config->get("wild-MaxZ"))));
                                 $pos->getLevel()->loadChunk($pos->getX(),$pos->getZ());
                                 $pos->getLevel()->getChunk($pos->getX(),$pos->getZ(),true);
                                 $pos->getLevel()->generateChunk($pos->getX(),$pos->getZ());
-                                $pos = $pos->getLevel()->getSafeSpawn(new Vector3($pos->getX(),rand(4,100),$pos->getZ()));
+                                $pos = $pos->getLevel()->getSafeSpawn(new Vector3($pos->getX(),$pos->getY(),$pos->getZ()));
 
                             //var_dump($pos);
                             //var_dump($pos->getLevel()->isChunkGenerated($pos->getX(),$pos->getZ()));
@@ -1057,7 +1057,7 @@ class essentialsTP extends PluginBase  implements CommandExecutor, Listener {
 
                             if($pos->getLevel()->isChunkLoaded($pos->getX(),$pos->getZ()))
                             {
-                                $sender->teleport($pos->getLevel()->getSafeSpawn(new Vector3($pos->getX(),rand(4,100),$pos->getZ())));
+                                $sender->teleport($pos->getLevel()->getSafeSpawn(new Vector3($pos->getX(),$pos->getY(),$pos->getZ())));
                                 $sender->sendMessage($this->config->get("Lang_teleport_wild"));
                                 return true;
                             }


### PR DESCRIPTION
Currently, /wild uses the MaxY config value for the Z coordinate. I've added a MaxZ config variable and put MaxY and MaxZ in the correct spots. Y was actually just an int between 4-100 and didn't use config, so I've changed Y to be an int between 75 and MaxY. I will add pull request with MinY in the future if there proves to be a reason to teleport into the ground.